### PR TITLE
All code4rena fixes

### DIFF
--- a/contracts/AuraBalRewardPool.sol
+++ b/contracts/AuraBalRewardPool.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 import { AuraMath } from "./AuraMath.sol";
-import { SafeMath } from "@openzeppelin/contracts-0.8/utils/math/SafeMath.sol";
 import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/utils/SafeERC20.sol";
 
@@ -21,7 +20,7 @@ import { IAuraLocker } from "./Interfaces.sol";
  *            - Penalty on claim at 20%
  */
 contract AuraBalRewardPool {
-    using SafeMath for uint256;
+    using AuraMath for uint256;
     using SafeERC20 for IERC20;
 
     IERC20 public immutable rewardToken;
@@ -30,7 +29,7 @@ contract AuraBalRewardPool {
 
     address public immutable rewardManager;
 
-    IAuraLocker public immutable auraLocker;
+    IAuraLocker public auraLocker;
     address public immutable penaltyForwarder;
     uint256 public pendingPenalty = 0;
     uint256 public immutable startTime;
@@ -50,6 +49,7 @@ contract AuraBalRewardPool {
     event Withdrawn(address indexed user, uint256 amount);
     event RewardPaid(address indexed user, uint256 reward, bool locked);
     event PenaltyForwarded(uint256 amount);
+    event Rescued();
 
     /**
      * @dev Simple constructoor
@@ -67,14 +67,17 @@ contract AuraBalRewardPool {
         address _penaltyForwarder,
         uint256 _startDelay
     ) {
+        require(_stakingToken != _rewardToken && _stakingToken != address(0), "!tokens");
         stakingToken = IERC20(_stakingToken);
         rewardToken = IERC20(_rewardToken);
+        require(_rewardManager != address(0), "!manager");
         rewardManager = _rewardManager;
+        require(_auraLocker != address(0), "!locker");
         auraLocker = IAuraLocker(_auraLocker);
+        require(_penaltyForwarder != address(0), "!locker");
         penaltyForwarder = _penaltyForwarder;
-        rewardToken.safeApprove(_auraLocker, type(uint256).max);
 
-        require(_startDelay < 2 weeks, "!delay");
+        require(_startDelay > 4 days && _startDelay < 2 weeks, "!delay");
         startTime = block.timestamp + _startDelay;
     }
 
@@ -178,6 +181,7 @@ contract AuraBalRewardPool {
         if (reward > 0) {
             rewards[msg.sender] = 0;
             if (_lock) {
+                rewardToken.safeIncreaseAllowance(address(auraLocker), reward);
                 auraLocker.lock(msg.sender, reward);
             } else {
                 uint256 penalty = (reward * 2) / 10;
@@ -197,6 +201,27 @@ contract AuraBalRewardPool {
         pendingPenalty = 0;
         rewardToken.safeTransfer(penaltyForwarder, toForward);
         emit PenaltyForwarded(toForward);
+    }
+
+    /**
+     * @dev Rescues the reward token provided it hasn't been initiated yet
+     */
+    function rescueReward() public {
+        require(msg.sender == rewardManager, "!rescuer");
+        require(block.timestamp < startTime && rewardRate == 0, "Already started");
+
+        uint256 balance = rewardToken.balanceOf(address(this));
+        rewardToken.transfer(rewardManager, balance);
+
+        emit Rescued();
+    }
+
+    /**
+     * @dev Updates the locker address
+     */
+    function setLocker(address _newLocker) external {
+        require(msg.sender == rewardManager, "!auth");
+        auraLocker = IAuraLocker(_newLocker);
     }
 
     /**

--- a/contracts/AuraClaimZap.sol
+++ b/contracts/AuraClaimZap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 import { AuraMath } from "./AuraMath.sol";
 import { IAuraLocker, ICrvDepositorWrapper } from "./Interfaces.sol";
@@ -206,15 +206,13 @@ contract AuraClaimZap {
         }
 
         //stake up to given amount of cvx
-        if (depositCvxMaxAmount > 0) {
+        if (depositCvxMaxAmount > 0 && _checkOption(options, uint256(Options.LockCvx))) {
             uint256 cvxBalance = IERC20(cvx).balanceOf(msg.sender).sub(removeCvxBalance);
             cvxBalance = AuraMath.min(cvxBalance, depositCvxMaxAmount);
             if (cvxBalance > 0) {
                 //pull cvx
                 IERC20(cvx).safeTransferFrom(msg.sender, address(this), cvxBalance);
-                if (_checkOption(options, uint256(Options.LockCvx))) {
-                    IAuraLocker(locker).lock(msg.sender, cvxBalance);
-                }
+                IAuraLocker(locker).lock(msg.sender, cvxBalance);
             }
         }
     }

--- a/contracts/AuraLocker.sol
+++ b/contracts/AuraLocker.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
-pragma experimental ABIEncoderV2;
+pragma solidity 0.8.11;
 
 import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/utils/SafeERC20.sol";
@@ -69,7 +68,7 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
 
     // Rewards
     address[] public rewardTokens;
-    uint256 public queuedCvxCrvRewards = 0;
+    mapping(address => uint256) public queuedRewards;
     uint256 public constant newRewardRatio = 830;
     //     Core reward data
     mapping(address => RewardData) public rewardData;
@@ -100,6 +99,8 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
     mapping(address => mapping(uint256 => uint256)) public delegateeUnlocks;
 
     // Config
+    //     Blacklisted smart contract interactions
+    mapping(address => bool) public blacklist;
     //     Tokens
     IERC20 public immutable stakingToken;
     address public immutable cvxCrv;
@@ -130,6 +131,7 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
     event KickReward(address indexed _user, address indexed _kicked, uint256 _reward);
     event RewardAdded(address indexed _token, uint256 _reward);
 
+    event BlacklistModified(address account, bool blacklisted);
     event KickIncentiveSet(uint256 rate, uint256 delay);
     event Shutdown();
 
@@ -187,14 +189,37 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
         _;
     }
 
+    modifier notBlacklisted(address _sender, address _receiver) {
+        uint256 csS;
+        uint256 csR;
+        assembly {
+            csS := extcodesize(_sender)
+            csR := extcodesize(_receiver)
+        }
+        if (csS != 0) {
+            require(!blacklist[_sender], "blacklisted");
+        }
+        if (csR != 0) {
+            require(_sender == _receiver || !blacklist[_receiver], "blacklisted");
+        }
+        _;
+    }
+
     /***************************************
                     ADMIN
     ****************************************/
+
+    function modifyBlacklist(address _account, bool _blacklisted) external onlyOwner {
+        blacklist[_account] = _blacklisted;
+        emit BlacklistModified(_account, _blacklisted);
+    }
 
     // Add a new reward token to be distributed to stakers
     function addReward(address _rewardsToken, address _distributor) external onlyOwner {
         require(rewardData[_rewardsToken].lastUpdateTime == 0, "Reward already exists");
         require(_rewardsToken != address(stakingToken), "Cannot add StakingToken as reward");
+        require(rewardTokens.length < 5, "Max rewards length");
+
         rewardTokens.push(_rewardsToken);
         rewardData[_rewardsToken].lastUpdateTime = uint32(block.timestamp);
         rewardData[_rewardsToken].periodFinish = uint32(block.timestamp);
@@ -255,7 +280,7 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
     }
 
     //lock tokens
-    function _lock(address _account, uint256 _amount) internal {
+    function _lock(address _account, uint256 _amount) internal notBlacklisted(msg.sender, _account) {
         require(_amount > 0, "Cannot stake 0");
         require(!isShutdown, "shutdown");
 
@@ -318,6 +343,21 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
         }
     }
 
+    function getReward(address _account, bool[] calldata _skipIdx) external nonReentrant updateReward(_account) {
+        uint256 rewardTokensLength = rewardTokens.length;
+        require(_skipIdx.length == rewardTokensLength, "!arr");
+        for (uint256 i; i < rewardTokensLength; i++) {
+            if (_skipIdx[i]) continue;
+            address _rewardsToken = rewardTokens[i];
+            uint256 reward = userData[_account][_rewardsToken].rewards;
+            if (reward > 0) {
+                userData[_account][_rewardsToken].rewards = 0;
+                IERC20(_rewardsToken).safeTransfer(_account, reward);
+                emit RewardPaid(_account, _rewardsToken, reward);
+            }
+        }
+    }
+
     function checkpointEpoch() external {
         _checkpointEpoch();
     }
@@ -325,14 +365,13 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
     //insert a new epoch if needed. fill in any gaps
     function _checkpointEpoch() internal {
         uint256 currentEpoch = block.timestamp.div(rewardsDuration).mul(rewardsDuration);
-        uint256 epochindex = epochs.length;
 
         //first epoch add in constructor, no need to check 0 length
         //check to add
-        if (epochs[epochindex - 1].date < currentEpoch) {
-            //fill any epoch gaps until the next epoch date.
-            while (epochs[epochs.length - 1].date != currentEpoch) {
-                uint256 nextEpochDate = uint256(epochs[epochs.length - 1].date).add(rewardsDuration);
+        uint256 nextEpochDate = uint256(epochs[epochs.length - 1].date);
+        if (nextEpochDate < currentEpoch) {
+            while (nextEpochDate != currentEpoch) {
+                nextEpochDate = nextEpochDate.add(rewardsDuration);
                 epochs.push(Epoch({ supply: 0, date: uint32(nextEpochDate) }));
             }
         }
@@ -401,7 +440,7 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
                 uint256 currentEpoch = block.timestamp.sub(_checkDelay).div(rewardsDuration).mul(rewardsDuration);
                 uint256 epochsover = currentEpoch.sub(uint256(locks[length - 1].unlockTime)).div(rewardsDuration);
                 uint256 rRate = AuraMath.min(kickRewardPerEpoch.mul(epochsover + 1), denominator);
-                reward = uint256(locks[length - 1].amount).mul(rRate).div(denominator);
+                reward = uint256(locked).mul(rRate).div(denominator);
             }
         } else {
             //use a processed index(nextUnlockIndex) to not loop as much
@@ -817,18 +856,20 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
                 REWARD FUNDING
     ****************************************/
 
-    function queueNewRewards(uint256 _rewards) external nonReentrant {
-        require(rewardDistributors[cvxCrv][msg.sender], "!authorized");
+    function queueNewRewards(address _rewardsToken, uint256 _rewards) external nonReentrant {
+        require(rewardDistributors[_rewardsToken][msg.sender], "!authorized");
         require(_rewards > 0, "No reward");
 
-        RewardData storage rdata = rewardData[cvxCrv];
+        RewardData storage rdata = rewardData[_rewardsToken];
 
-        IERC20(cvxCrv).safeTransferFrom(msg.sender, address(this), _rewards);
+        IERC20(_rewardsToken).safeTransferFrom(msg.sender, address(this), _rewards);
 
-        _rewards = _rewards.add(queuedCvxCrvRewards);
+        _rewards = _rewards.add(queuedRewards[_rewardsToken]);
+        require(_rewards < 1e25, "!rewards");
+
         if (block.timestamp >= rdata.periodFinish) {
-            _notifyReward(cvxCrv, _rewards);
-            queuedCvxCrvRewards = 0;
+            _notifyReward(_rewardsToken, _rewards);
+            queuedRewards[_rewardsToken] = 0;
             return;
         }
 
@@ -838,23 +879,11 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
         uint256 currentAtNow = rdata.rewardRate * elapsedTime;
         uint256 queuedRatio = currentAtNow.mul(1000).div(_rewards);
         if (queuedRatio < newRewardRatio) {
-            _notifyReward(cvxCrv, _rewards);
-            queuedCvxCrvRewards = 0;
+            _notifyReward(_rewardsToken, _rewards);
+            queuedRewards[_rewardsToken] = 0;
         } else {
-            queuedCvxCrvRewards = _rewards;
+            queuedRewards[_rewardsToken] = _rewards;
         }
-    }
-
-    function notifyRewardAmount(address _rewardsToken, uint256 _reward) external {
-        require(_rewardsToken != cvxCrv, "Use queueNewRewards");
-        require(rewardDistributors[_rewardsToken][msg.sender], "Must be rewardsDistributor");
-        require(_reward > 0, "No reward");
-
-        _notifyReward(_rewardsToken, _reward);
-
-        // handle the transfer of reward tokens via `transferFrom` to reduce the number
-        // of transactions required and ensure correctness of the _reward amount
-        IERC20(_rewardsToken).safeTransferFrom(msg.sender, address(this), _reward);
     }
 
     function _notifyReward(address _rewardsToken, uint256 _reward) internal updateReward(address(0)) {
@@ -867,6 +896,10 @@ contract AuraLocker is ReentrancyGuard, Ownable, IAuraLocker {
             uint256 leftover = remaining.mul(rdata.rewardRate);
             rdata.rewardRate = _reward.add(leftover).div(rewardsDuration).to96();
         }
+
+        // Equivalent to 10 million tokens over a weeks duration
+        require(rdata.rewardRate < 1e20, "!rewardRate");
+        require(lockedSupply >= 1e20, "!balance");
 
         rdata.lastUpdateTime = block.timestamp.to32();
         rdata.periodFinish = block.timestamp.add(rewardsDuration).to32();

--- a/contracts/AuraMath.sol
+++ b/contracts/AuraMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 /// @notice A library for performing overflow-/underflow-safe math,
 /// updated with awesomeness from of DappHub (https://github.com/dapphub/ds-math).

--- a/contracts/AuraMinter.sol
+++ b/contracts/AuraMinter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 import { Ownable } from "@openzeppelin/contracts-0.8/access/Ownable.sol";
 import { AuraToken } from "./Aura.sol";
@@ -7,7 +7,7 @@ import { AuraToken } from "./Aura.sol";
 /**
  * @title   AuraMinter
  * @notice  Wraps the AuraToken minterMint function and protects from inflation until
- *          4 years have passed.
+ *          3 years have passed.
  * @dev     Ownership initially owned by the DAO, but likely transferred to smart contract
  *          wrapper or additional value system at some stage as directed by token holders.
  */

--- a/contracts/AuraPenaltyForwarder.sol
+++ b/contracts/AuraPenaltyForwarder.sol
@@ -1,44 +1,47 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 import { IExtraRewardsDistributor } from "./Interfaces.sol";
+import { Ownable } from "@openzeppelin/contracts-0.8/access/Ownable.sol";
 import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title AuraPenaltyForwarder
- * @dev Receives a given token and forwards it on to a distribution contract. Used during
- *      the bootstrapping period to forward AURA rewards to the extra rewards distributor.
+ * @dev Receives a given token and forwards it on to a distribution contract.
  */
-contract AuraPenaltyForwarder {
+contract AuraPenaltyForwarder is Ownable {
     using SafeERC20 for IERC20;
 
-    IExtraRewardsDistributor public immutable distributor;
+    IExtraRewardsDistributor public distributor;
     IERC20 public immutable token;
 
     uint256 public immutable distributionDelay;
     uint256 public lastDistribution;
 
     event Forwarded(uint256 amount);
+    event DistributorChanged(address newDistributor);
 
     /**
      * @dev During deployment approves the distributor to spend all tokens
      * @param _distributor  Contract that will distribute tokens
      * @param _token        Token to be distributed
      * @param _delay        Delay between each distribution trigger
+     * @param _dao          Address of DAO
      */
     constructor(
         address _distributor,
         address _token,
-        uint256 _delay
-    ) {
+        uint256 _delay,
+        address _dao
+    ) Ownable() {
         distributor = IExtraRewardsDistributor(_distributor);
         token = IERC20(_token);
         distributionDelay = _delay;
 
         lastDistribution = block.timestamp;
 
-        token.safeApprove(address(distributor), type(uint256).max);
+        _transferOwnership(_dao);
     }
 
     /**
@@ -51,8 +54,17 @@ contract AuraPenaltyForwarder {
         uint256 bal = token.balanceOf(address(this));
         require(bal > 0, "!empty");
 
+        token.safeIncreaseAllowance(address(distributor), bal);
         distributor.addReward(address(token), bal);
 
         emit Forwarded(bal);
+    }
+
+    /**
+     * @dev Updates distributor address
+     */
+    function setDistributor(address _distributor) public onlyOwner {
+        distributor = IExtraRewardsDistributor(_distributor);
+        emit DistributorChanged(_distributor);
     }
 }

--- a/contracts/AuraVestedEscrow.sol
+++ b/contracts/AuraVestedEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 import { IAuraLocker } from "./Interfaces.sol";
 import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
@@ -24,6 +24,7 @@ contract AuraVestedEscrow is ReentrancyGuard {
     IERC20 public immutable rewardToken;
 
     address public admin;
+    address public immutable funder;
     IAuraLocker public auraLocker;
 
     uint256 public immutable startTime;
@@ -58,6 +59,7 @@ contract AuraVestedEscrow is ReentrancyGuard {
 
         rewardToken = IERC20(rewardToken_);
         admin = admin_;
+        funder = msg.sender;
         auraLocker = IAuraLocker(auraLocker_);
 
         startTime = starttime_;
@@ -94,7 +96,10 @@ contract AuraVestedEscrow is ReentrancyGuard {
      * @param _amount     Arrary of amount of rewardTokens to vest
      */
     function fund(address[] calldata _recipient, uint256[] calldata _amount) external nonReentrant {
+        require(_recipient.length == _amount.length, "!arr");
         require(!initialised, "initialised already");
+        require(msg.sender == funder, "!funder");
+        require(block.timestamp < startTime, "already started");
 
         uint256 totalAmount = 0;
         for (uint256 i = 0; i < _recipient.length; i++) {

--- a/contracts/BalLiquidityProvider.sol
+++ b/contracts/BalLiquidityProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 import { IVault } from "./Interfaces.sol";
 import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
@@ -46,6 +46,7 @@ contract BalLiquidityProvider {
     function provideLiquidity(bytes32 _poolId, IVault.JoinPoolRequest memory _request) public {
         require(msg.sender == provider, "!auth");
         require(_request.assets.length == 2 && _request.maxAmountsIn.length == 2, "!valid");
+        require(_request.assets[0] != _request.assets[1], "!assets");
         require(pairToken.balanceOf(address(this)) > minPairAmount, "!minLiq");
 
         for (uint256 i = 0; i < 2; i++) {
@@ -54,7 +55,10 @@ contract BalLiquidityProvider {
 
             IERC20 tkn = IERC20(asset);
             uint256 bal = tkn.balanceOf(address(this));
-            require(bal > 0 && bal == _request.maxAmountsIn[i], "!bal");
+            require(
+                bal > 0 && bal >= _request.maxAmountsIn[i] && bal <= (_request.maxAmountsIn[i] * 102) / 100,
+                "!bal"
+            );
 
             tkn.safeApprove(address(bVault), 0);
             tkn.safeApprove(address(bVault), bal);

--- a/contracts/ClaimFeesHelper.sol
+++ b/contracts/ClaimFeesHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
 import { IFeeDistributor } from "./mocks/balancer/MockFeeDistro.sol";

--- a/contracts/CrvDepositorWrapper.sol
+++ b/contracts/CrvDepositorWrapper.sol
@@ -3,8 +3,7 @@ pragma solidity 0.8.11;
 
 import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/utils/SafeERC20.sol";
-import { IVault, IPriceOracle, ICrvDepositorWrapper, IAsset } from "./Interfaces.sol";
-import { IVault } from "./Interfaces.sol";
+import { IVault, ICrvDepositorWrapper, IPriceOracle, IAsset } from "./Interfaces.sol";
 
 interface ICrvDepositor {
     function depositFor(

--- a/contracts/Interfaces.sol
+++ b/contracts/Interfaces.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.11;
-pragma abicoder v2;
 
 interface IPriceOracle {
     struct OracleAverageQuery {
@@ -122,9 +121,7 @@ interface IAuraLocker {
 
     function totalSupplyAtEpoch(uint256 _epoch) external view returns (uint256 supply);
 
-    function queueNewRewards(uint256 _rewards) external;
-
-    function notifyRewardAmount(address _rewardsToken, uint256 reward) external;
+    function queueNewRewards(address _rewardsToken, uint256 reward) external;
 
     function getReward(address _account, bool _stake) external;
 

--- a/contracts/RewardPoolDepositWrapper.sol
+++ b/contracts/RewardPoolDepositWrapper.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+import { IVault } from "./Interfaces.sol";
+import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/utils/SafeERC20.sol";
+
+interface RewardPool {
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+}
+
+/**
+ * @title   RewardPoolDepositWrapper
+ * @notice  Peripheral contract that allows users to deposit into a Balancer pool and then stake their BPT
+ *          into Aura in 1 tx. Flow:
+ *            - rawToken.transferFrom(user, address(this))
+ *            - vault.deposit(rawToken), receive poolToken
+ *            - poolToken.approve(rewardPool)
+ *            - rewardPool.deposit(poolToken), converts to auraBPT and then deposits
+ */
+contract RewardPoolDepositWrapper {
+    using SafeERC20 for IERC20;
+
+    IVault public immutable bVault;
+
+    constructor(address _bVault) {
+        bVault = IVault(_bVault);
+    }
+
+    /**
+     * @dev Deposits a single raw token into a BPT before depositing in reward pool.
+     *      Requires sender to approve this contract before calling.
+     */
+    function depositSingle(
+        address _rewardPoolAddress,
+        IERC20 _inputToken,
+        uint256 _inputAmount,
+        bytes32 _balancerPoolId,
+        IVault.JoinPoolRequest memory _request
+    ) external {
+        // 1. Transfer input token
+        _inputToken.safeTransferFrom(msg.sender, address(this), _inputAmount);
+
+        // 2. Deposit to balancer pool
+        (address pool, ) = bVault.getPool(_balancerPoolId);
+
+        _inputToken.approve(address(bVault), _inputAmount);
+        bVault.joinPool(_balancerPoolId, address(this), address(this), _request);
+
+        uint256 minted = IERC20(pool).balanceOf(address(this));
+        require(minted > 0, "!mint");
+
+        uint256 inputBalAfter = _inputToken.balanceOf(address(this));
+        require(inputBalAfter == 0, "!input");
+
+        // 3. Deposit to reward pool
+        IERC20(pool).approve(_rewardPoolAddress, minted);
+        RewardPool(_rewardPoolAddress).deposit(minted, msg.sender);
+    }
+}

--- a/contracts/mocks/MockAuraLockor.sol
+++ b/contracts/mocks/MockAuraLockor.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/utils/SafeERC20.sol";
+
+import { IAuraLocker } from "../Interfaces.sol";
+
+/**
+ * @title   AuraBalRewardPool
+ * @author  Synthetix -> ConvexFinance -> adapted
+ * @dev     Modifications from convex-platform/contracts/contracts/BaseRewardPool.sol:
+ *            - Delayed start (tokens transferred then delay is enforced before notification)
+ *            - One time duration of 14 days
+ *            - Remove child reward contracts
+ *            - Penalty on claim at 20%
+ */
+contract MockAuraLockor {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable aura;
+    IAuraLocker public immutable locker;
+
+    constructor(address _aura, address _locker) {
+        aura = IERC20(_aura);
+        locker = IAuraLocker(_locker);
+    }
+
+    function lock(uint256 _amount) external {
+        aura.safeTransferFrom(msg.sender, address(this), _amount);
+        aura.safeIncreaseAllowance(address(locker), _amount);
+        locker.lock(address(this), _amount);
+    }
+
+    function lockFor(address _for, uint256 _amount) external {
+        aura.safeTransferFrom(msg.sender, address(this), _amount);
+        aura.safeIncreaseAllowance(address(locker), _amount);
+        locker.lock(_for, _amount);
+    }
+}

--- a/contracts/mocks/MockAuraMath.sol
+++ b/contracts/mocks/MockAuraMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 import { AuraMath, AuraMath32, AuraMath112, AuraMath224 } from "../AuraMath.sol";
 

--- a/contracts/mocks/balancer/MockBalancerVault.sol
+++ b/contracts/mocks/balancer/MockBalancerVault.sol
@@ -71,5 +71,6 @@ contract MockBalancerVault {
             IERC20(tokenA).transferFrom(funds.sender, address(this), singleSwap.amount);
             IERC20(tokenB).transfer(funds.recipient, singleSwap.amount);
         }
+        return singleSwap.amount;
     }
 }

--- a/contracts/mocks/balancer/MockFeeDistro.sol
+++ b/contracts/mocks/balancer/MockFeeDistro.sol
@@ -41,7 +41,9 @@ contract MockFeeDistributor is IFeeDistributor {
         return rates;
     }
 
-    function getTokenTimeCursor(IERC20 token) external view returns (uint256) {
+    function getTokenTimeCursor(
+        IERC20 /* token */
+    ) external view returns (uint256) {
         return 1;
     }
 }

--- a/contracts/mocks/curve/MockCurveMinter.sol
+++ b/contracts/mocks/curve/MockCurveMinter.sol
@@ -17,6 +17,10 @@ contract MockCurveMinter is IMinter {
         rate = _rate;
     }
 
+    function setRate(uint256 _rate) external {
+        rate = _rate;
+    }
+
     function mint(address) external {
         crv.transfer(msg.sender, rate);
     }

--- a/convex-platform/contracts/contracts/BaseRewardPool.sol
+++ b/convex-platform/contracts/contracts/BaseRewardPool.sol
@@ -125,7 +125,11 @@ contract BaseRewardPool {
     function addExtraReward(address _reward) external returns(bool){
         require(msg.sender == rewardManager, "!authorized");
         require(_reward != address(0),"!reward setting");
-
+        
+        if(extraRewards.length >= 12){
+            return false;
+        }
+        
         extraRewards.push(_reward);
         return true;
     }

--- a/convex-platform/contracts/contracts/BaseRewardPool4626.sol
+++ b/convex-platform/contracts/contracts/BaseRewardPool4626.sol
@@ -62,7 +62,7 @@ contract BaseRewardPool4626 is BaseRewardPool, ReentrancyGuard, IERC4626 {
         IDeposit(operator).deposit(pid, assets, false);
         uint256 balAfter = stakingToken.balanceOf(address(this));
 
-        require(balAfter - balBefore >= assets, "!deposit");
+        require(balAfter.sub(balBefore) >= assets, "!deposit");
 
         // Perform stake manually, now that the funds have been received
         _processStake(assets, receiver);

--- a/convex-platform/contracts/contracts/Booster.sol
+++ b/convex-platform/contracts/contracts/Booster.sol
@@ -136,7 +136,7 @@ contract Booster{
      * @notice Fee Manager can update the fees (lockIncentive, stakeIncentive, earmarkIncentive, platformFee)
      */
     function setFeeManager(address _feeM) external {
-        require(msg.sender == feeManager, "!auth");
+        require(msg.sender == owner, "!auth");
         feeManager = _feeM;
 
         emit FeeManagerUpdated(_feeM);
@@ -189,7 +189,7 @@ contract Booster{
      * @notice Vote Delegate has the rights to cast votes on the VoterProxy via the Booster
      */
     function setVoteDelegate(address _voteDelegate) external {
-        require(msg.sender==voteDelegate, "!auth");
+        require(msg.sender==owner, "!auth");
         voteDelegate = _voteDelegate;
 
         emit VoteDelegateUpdated(_voteDelegate);
@@ -235,6 +235,7 @@ contract Booster{
                 emit FeeInfoUpdated(_feeDistro, lockRewards, crv);
             } else {
                 //create a new reward contract for the new token
+                require(IRewards(lockRewards).extraRewardsLength() < 10, "too many rewards");
                 address rewards = IRewardFactory(rewardFactory).CreateTokenRewards(_feeToken, lockRewards, address(this));
                 feeTokens[_feeToken] = FeeDistro({
                     distro: _feeDistro,
@@ -369,7 +370,7 @@ contract Booster{
     }
 
     /**
-     * @notice Shuts down the WHOLE SYSTEM by withdrawing all the LP tokens ot here and then allowing
+     * @notice Shuts down the WHOLE SYSTEM by withdrawing all the LP tokens to here and then allowing
      *         for subsequent withdrawal by any depositors.
      */
     function shutdownSystem() external{
@@ -566,7 +567,7 @@ contract Booster{
 
     /**
      * @notice Basically a hugely pivotal function.
-     *         Repsonsible for collecting the crv from gauge, and then redistributing to the correct place.
+     *         Responsible for collecting the crv from gauge, and then redistributing to the correct place.
      *         Pays the caller a fee to process this.
      */
     function _earmarkRewards(uint256 _pid) internal {
@@ -628,7 +629,7 @@ contract Booster{
 
     /**
      * @notice Basically a hugely pivotal function.
-     *         Repsonsible for collecting the crv from gauge, and then redistributing to the correct place.
+     *         Responsible for collecting the crv from gauge, and then redistributing to the correct place.
      *         Pays the caller a fee to process this.
      */
     function earmarkRewards(uint256 _pid) external returns(bool){

--- a/convex-platform/contracts/contracts/ExtraRewardStashV3.sol
+++ b/convex-platform/contracts/contracts/ExtraRewardStashV3.sol
@@ -139,6 +139,8 @@ contract ExtraRewardStashV3 {
     function setExtraReward(address _token) external{
         //owner of booster can set extra rewards
         require(IDeposit(operator).owner() == msg.sender, "!owner");
+        require(tokenList.length < 4, "too many rewards");
+
         setToken(_token);
     }
 

--- a/convex-platform/contracts/contracts/Interfaces.sol
+++ b/convex-platform/contracts/contracts/Interfaces.sol
@@ -70,6 +70,7 @@ interface IRewards{
     function queueNewRewards(uint256) external;
     function notifyRewardAmount(uint256) external;
     function addExtraReward(address) external;
+    function extraRewardsLength() external view returns (uint256);
     function stakingToken() external view returns (address);
     function rewardToken() external view returns(address);
     function earned(address account) external view returns (uint256);

--- a/convex-platform/contracts/contracts/StashFactoryV2.sol
+++ b/convex-platform/contracts/contracts/StashFactoryV2.sol
@@ -54,6 +54,7 @@ contract StashFactoryV2 {
     //function calls are different depending on the version of curve gauges so determine which stash type is needed
     function CreateStash(uint256 _pid, address _gauge, address _staker, uint256 _stashVersion) external returns(address){
         require(msg.sender == operator, "!authorized");
+        require(_gauge != address(0), "!gauge");
 
         if(_stashVersion == uint256(3) && IsV3(_gauge)){
             //v3

--- a/convex-platform/contracts/contracts/VoterProxy.sol
+++ b/convex-platform/contracts/contracts/VoterProxy.sol
@@ -234,7 +234,7 @@ contract VoterProxy {
     
     
     /**
-     * @notice  Lock CRV in curves voting escrow contract
+     * @notice  Lock CRV in Curve's voting escrow contract
      * @dev     Called by the CrvDepositor contract
      * @param _value      Amount of crv to lock
      * @param _unlockTime Timestamp to unlock (max is 4 years)

--- a/scripts/deploySystem.ts
+++ b/scripts/deploySystem.ts
@@ -1,5 +1,6 @@
 import { BigNumber as BN, ContractReceipt, Signer } from "ethers";
 import {
+    RewardPoolDepositWrapper,
     ExtraRewardsDistributor,
     AuraPenaltyForwarder,
     IInvestmentPoolFactory__factory,
@@ -67,6 +68,7 @@ import {
     AuraMerkleDrop__factory,
     ClaimFeesHelper,
     ClaimFeesHelper__factory,
+    RewardPoolDepositWrapper__factory,
 } from "../types/generated";
 import { AssetHelpers } from "@balancer-labs/balancer-js";
 import { Chain, deployContract, waitForTx } from "../tasks/utils";
@@ -211,6 +213,7 @@ interface Phase3Deployed extends Phase2Deployed {
 interface SystemDeployed extends Phase3Deployed {
     claimZap: AuraClaimZap;
     feeCollector: ClaimFeesHelper;
+    rewardDepositWrapper: RewardPoolDepositWrapper;
 }
 
 function getPoolAddress(utils, receipt: ContractReceipt): string {
@@ -323,7 +326,7 @@ async function deployPhase2(
         .reduce((p, c) => p.add(c.recipients.reduce((pp, cc) => pp.add(cc.amount), BN.from(0))), BN.from(0));
     const premine = premineIncetives.add(totalVested);
     const checksum = premine.add(distroList.miningRewards);
-    if (!checksum.eq(simpleToExactAmount(100, 24))) {
+    if (!checksum.eq(simpleToExactAmount(100, 24)) || !premine.eq(simpleToExactAmount(50, 24))) {
         console.log(checksum.toString());
         throw console.error();
     }
@@ -543,7 +546,7 @@ async function deployPhase2(
         hre,
         new AuraPenaltyForwarder__factory(deployer),
         "AuraPenaltyForwarder",
-        [extraRewardsDistributor.address, cvx.address, ONE_WEEK.mul(7).div(2)],
+        [extraRewardsDistributor.address, cvx.address, ONE_WEEK.mul(7).div(2), multisigs.daoMultisig],
         {},
         debug,
         waitForBlocks,
@@ -578,7 +581,7 @@ async function deployPhase2(
     tx = await voterProxy.setOperator(booster.address);
     await waitForTx(tx, debug, waitForBlocks);
 
-    tx = await cvx.init(deployerAddress, premine.toString(), minter.address);
+    tx = await cvx.init(deployerAddress, minter.address);
     await waitForTx(tx, debug, waitForBlocks);
 
     tx = await stashFactory.setImplementation(ZERO_ADDRESS, ZERO_ADDRESS, stashV3.address);
@@ -641,6 +644,12 @@ async function deployPhase2(
     await waitForTx(tx, debug, waitForBlocks);
 
     tx = await booster.setOwner(boosterOwner.address);
+    await waitForTx(tx, debug, waitForBlocks);
+
+    tx = await extraRewardsDistributor.modifyWhitelist(penaltyForwarder.address, true);
+    await waitForTx(tx, debug, waitForBlocks);
+
+    tx = await extraRewardsDistributor.transferOwnership(multisigs.daoMultisig);
     await waitForTx(tx, debug, waitForBlocks);
 
     // -----------------------------
@@ -741,7 +750,7 @@ async function deployPhase2(
             tokens: poolTokens,
             name: `Balancer ${await cvxCrv.symbol()} Stable Pool`,
             symbol: `B-${await cvxCrv.symbol()}-STABLE`,
-            swapFee: simpleToExactAmount(3, 15),
+            swapFee: simpleToExactAmount(6, 15),
             ampParameter: 25,
         };
         if (debug) {
@@ -815,7 +824,7 @@ async function deployPhase2(
     tx = await cvx.transfer(chef.address, distroList.lpIncentives);
     await waitForTx(tx, debug, waitForBlocks);
 
-    tx = await chef.add(1000, cvxCrvBpt.address, ZERO_ADDRESS, false);
+    tx = await chef.add(1000, cvxCrvBpt.address, ZERO_ADDRESS);
     await waitForTx(tx, debug, waitForBlocks);
 
     tx = await chef.transferOwnership(multisigs.daoMultisig);
@@ -1017,7 +1026,7 @@ async function deployPhase3(
             tokens: poolTokens,
             name: `Balancer 80 ${await cvx.symbol()} 20 WETH`,
             symbol: `B-80${await cvx.symbol()}-20WETH`,
-            swapFee: simpleToExactAmount(6, 15),
+            swapFee: simpleToExactAmount(1, 16),
             weights: weights as BN[],
         };
         if (debug) {
@@ -1107,7 +1116,17 @@ async function deployPhase4(
         waitForBlocks,
     );
 
-    return { ...deployment, claimZap, feeCollector };
+    const rewardDepositWrapper = await deployContract<RewardPoolDepositWrapper>(
+        hre,
+        new RewardPoolDepositWrapper__factory(deployer),
+        "RewardPoolDepositWrapper",
+        [config.balancerVault],
+        {},
+        debug,
+        waitForBlocks,
+    );
+
+    return { ...deployment, claimZap, feeCollector, rewardDepositWrapper };
 }
 
 export {

--- a/test-fork/FullDeployment.spec.ts
+++ b/test-fork/FullDeployment.spec.ts
@@ -440,7 +440,7 @@ describe("Full Deployment", () => {
                     const { naming, multisigs } = config;
                     expect(await cvxLocker.rewardTokens(0)).eq(cvxCrv.address);
                     await expect(cvxLocker.rewardTokens(1)).to.be.reverted;
-                    expect(await cvxLocker.queuedCvxCrvRewards()).eq(0);
+                    expect(await cvxLocker.queuedRewards(cvxCrv.address)).eq(0);
                     expect(await cvxLocker.rewardDistributors(cvxCrv.address, cvxStakingProxy.address)).eq(true);
                     expect(await cvxLocker.lockedSupply()).eq(0);
                     expect(await cvxLocker.stakingToken()).eq(cvx.address);
@@ -637,12 +637,14 @@ describe("Full Deployment", () => {
 
                     expect(await penaltyForwarder.distributor()).eq(extraRewardsDistributor.address);
                     expect(await penaltyForwarder.token()).eq(cvx.address);
+                    expect(await penaltyForwarder.owner()).eq(config.multisigs.daoMultisig);
                     expect(await penaltyForwarder.distributionDelay()).eq(ONE_WEEK.mul(7).div(2));
                     assertBNClose(await penaltyForwarder.lastDistribution(), await getTimestamp(), 100);
                 });
                 it("extraRewardsDistributor has correct config", async () => {
                     const { extraRewardsDistributor, cvxLocker } = phase2;
                     expect(await extraRewardsDistributor.auraLocker()).eq(cvxLocker.address);
+                    expect(await extraRewardsDistributor.owner()).eq(config.multisigs.daoMultisig);
                 });
             });
         });
@@ -1587,7 +1589,7 @@ describe("Full Deployment", () => {
 
                     const callerCvxCrvBalanceBefore = await phase4.cvxCrv.balanceOf(stakerAddress);
                     const cvxLockerCvxCrvBalanceBefore = await phase4.cvxCrv.balanceOf(phase4.cvxLocker.address);
-                    await phase4.cvxStakingProxy.connect(staker.signer).distribute();
+                    await phase4.cvxStakingProxy.connect(staker.signer)["distribute()"]();
                     const callerCvxCrvBalanceAfter = await phase4.cvxCrv.balanceOf(stakerAddress);
                     const cvxLockerCvxCrvBalanceAfter = await phase4.cvxCrv.balanceOf(phase4.cvxLocker.address);
 
@@ -1717,10 +1719,10 @@ describe("Full Deployment", () => {
                 });
                 it("allows boosterOwner to call all fns on booster", async () => {
                     const { booster, boosterOwner } = phase4;
-                    await booster.connect(daoSigner.signer).setFeeManager(boosterOwner.address);
 
+                    await boosterOwner.connect(daoSigner.signer).setFeeManager(config.multisigs.treasuryMultisig);
+                    expect(await booster.feeManager()).eq(config.multisigs.treasuryMultisig);
                     await boosterOwner.connect(daoSigner.signer).setFeeManager(daoSigner.address);
-                    expect(await booster.feeManager()).eq(daoSigner.address);
 
                     await boosterOwner.connect(daoSigner.signer).setFactories(ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS);
                     expect(await booster.stashFactory()).eq(ZERO_ADDRESS);
@@ -1730,9 +1732,9 @@ describe("Full Deployment", () => {
                     await boosterOwner.connect(daoSigner.signer).setArbitrator(ZERO_ADDRESS);
                     expect(await booster.rewardArbitrator()).eq(ZERO_ADDRESS);
 
-                    await booster.connect(daoSigner.signer).setVoteDelegate(boosterOwner.address);
                     await boosterOwner.connect(daoSigner.signer).setVoteDelegate(ZERO_ADDRESS);
                     expect(await booster.voteDelegate()).eq(ZERO_ADDRESS);
+                    await boosterOwner.connect(daoSigner.signer).setVoteDelegate(daoSigner.address);
 
                     await boosterOwner.connect(daoSigner.signer).updateFeeInfo(config.addresses.token, false);
                     expect((await booster.feeTokens(config.addresses.token)).active).eq(false);
@@ -1798,7 +1800,7 @@ describe("Full Deployment", () => {
                     const cvxCrvBalanceBefore = await phase4.cvxCrv.balanceOf(stakerAddress);
                     await getCrv(phase4.booster.address, simpleToExactAmount(1));
                     await phase4.booster.earmarkRewards(0);
-                    await phase4.cvxStakingProxy.distribute();
+                    await phase4.cvxStakingProxy["distribute()"]();
                     await increaseTime(ONE_HOUR);
                     const rewards = await phase4.cvxLocker.claimableRewards(stakerAddress);
                     expect(rewards[0].amount).gt(0);
@@ -1828,7 +1830,7 @@ describe("Full Deployment", () => {
                 // Check that a penalty has been accrued
                 const penaltyBal = await cvx.balanceOf(penaltyForwarder.address);
                 expect(penaltyBal).gt(0);
-                const distirbutorBalBefore = await cvx.balanceOf(extraRewardsDistributor.address);
+                const distributorBalBefore = await cvx.balanceOf(extraRewardsDistributor.address);
 
                 // Forward the penalty to rewardsDistributor
                 await penaltyForwarder.forward();
@@ -1836,7 +1838,7 @@ describe("Full Deployment", () => {
                 // Check the reward has been added
                 expect(await cvx.balanceOf(penaltyForwarder.address)).eq(0);
                 const distributorBalAfter = await cvx.balanceOf(extraRewardsDistributor.address);
-                expect(distributorBalAfter.sub(distirbutorBalBefore)).eq(penaltyBal);
+                expect(distributorBalAfter.sub(distributorBalBefore)).eq(penaltyBal);
                 expect(await extraRewardsDistributor.rewardEpochsCount(cvx.address)).eq(1);
 
                 // Check the reward is claimable

--- a/test/Aura.spec.ts
+++ b/test/Aura.spec.ts
@@ -69,23 +69,23 @@ describe("AuraToken", () => {
     });
     describe("@method AuraToken.init fails if ", async () => {
         it("caller is not the operator", async () => {
-            await expect(cvx.connect(deployer).init(DEAD_ADDRESS, 0, DEAD_ADDRESS)).to.revertedWith("Only operator");
+            await expect(cvx.connect(deployer).init(DEAD_ADDRESS, DEAD_ADDRESS)).to.revertedWith("Only operator");
         });
         it("called more than once", async () => {
-            await expect(cvx.init(DEAD_ADDRESS, 0, DEAD_ADDRESS)).to.revertedWith("Only operator");
+            await expect(cvx.init(DEAD_ADDRESS, DEAD_ADDRESS)).to.revertedWith("Only operator");
         });
         it("wrong amount of tokens", async () => {
-            await expect(cvx.init(DEAD_ADDRESS, 0, DEAD_ADDRESS)).to.revertedWith("Only operator");
+            await expect(cvx.init(DEAD_ADDRESS, DEAD_ADDRESS)).to.revertedWith("Only operator");
         });
         it("wrong minter address", async () => {
-            await expect(cvx.init(DEAD_ADDRESS, 0, DEAD_ADDRESS)).to.revertedWith("Only operator");
+            await expect(cvx.init(DEAD_ADDRESS, DEAD_ADDRESS)).to.revertedWith("Only operator");
         });
     });
 
-    it("@method AuraToken.updateOperator sets new operator", async () => {
+    it("@method AuraToken.updateOperator fails to set new operator", async () => {
         const previousOperator = await cvx.operator();
-        const tx = cvx.connect(deployer).updateOperator();
-        await expect(tx).to.emit(cvx, "OperatorChanged").withArgs(previousOperator, booster.address);
+        expect(previousOperator).eq(booster.address);
+        await expect(cvx.connect(deployer).updateOperator()).to.be.revertedWith("!operator");
     });
     it("@method AuraToken.mint does not mint if sender is not the operator", async () => {
         const beforeBalance = await cvx.balanceOf(aliceAddress);

--- a/test/AuraLocker.spec.ts
+++ b/test/AuraLocker.spec.ts
@@ -24,6 +24,8 @@ import {
     Booster,
     CrvDepositor,
     CvxCrvToken,
+    MockAuraLockor,
+    MockAuraLockor__factory,
     MockERC20,
     MockERC20__factory,
 } from "../types/generated";
@@ -215,7 +217,7 @@ describe("AuraLocker", () => {
 
     const setup = async () => {
         mocks = await deployMocks(hre, deployer);
-        const multisigs = await getMockMultisigs(accounts[0], accounts[0], accounts[0]);
+        const multisigs = await getMockMultisigs(accounts[5], accounts[6], accounts[7]);
         const distro = getMockDistro();
 
         const phase1 = await deployPhase1(hre, deployer, mocks.addresses);
@@ -229,7 +231,7 @@ describe("AuraLocker", () => {
             mocks.addresses,
         );
         const phase3 = await deployPhase3(hre, deployer, phase2, multisigs, mocks.addresses);
-        await phase3.poolManager.setProtectPool(false);
+        await phase3.poolManager.connect(accounts[7]).setProtectPool(false);
         const contracts = await deployPhase4(hre, deployer, phase3, mocks.addresses);
 
         alice = accounts[1];
@@ -268,7 +270,7 @@ describe("AuraLocker", () => {
 
         expect(stakingCrvBalance).to.equal(rate.mul(incentive).div(10000));
 
-        const tx = await cvxStakingProxy.distribute();
+        const tx = await cvxStakingProxy["distribute()"]();
         const receipt = await tx.wait();
         const event = receipt.events.find(e => e.event === "RewardsDistributed");
 
@@ -290,7 +292,7 @@ describe("AuraLocker", () => {
         expect(await auraLocker.cvxCrv(), "AuraLocker cvxCrv").to.equal(cvxCrv.address);
         expect(await auraLocker.cvxcrvStaking(), "AuraLocker cvxCrvStaking").to.equal(cvxCrvRewards.address);
         expect(await auraLocker.epochCount(), "AuraLocker epoch counts").to.equal(1);
-        expect(await auraLocker.queuedCvxCrvRewards(), "AuraLocker lockDuration").to.equal(0);
+        expect(await auraLocker.queuedRewards(cvxCrv.address), "AuraLocker lockDuration").to.equal(0);
         expect(await auraLocker.rewardPerToken(cvxCrv.address), "AuraLocker rewardPerToken").to.equal(0);
         expect(await auraLocker.lastTimeRewardApplicable(cvxCrv.address), "cvxCrv lastTimeRewardApplicable").to.gt(0);
         // expect(await auraLocker.rewardTokens(0),"AuraLocker lockDuration").to.equal( 86400 * 7 * 17);
@@ -391,7 +393,7 @@ describe("AuraLocker", () => {
             expect(stakingCrvBalance).to.equal(rate.mul(incentive).div(10000));
 
             const balBefore = await cvxCrv.balanceOf(auraLocker.address);
-            const tx = await cvxStakingProxy.distribute();
+            const tx = await cvxStakingProxy["distribute()"]();
             await tx.wait();
 
             const balAfter = await cvxCrv.balanceOf(auraLocker.address);
@@ -423,6 +425,31 @@ describe("AuraLocker", () => {
             ).to.equal(simpleToExactAmount(100));
         });
 
+        it("notify rewards ", async () => {
+            const amount = simpleToExactAmount(100);
+            const mockToken = await deployContract<MockERC20>(
+                hre,
+                new MockERC20__factory(deployer),
+                "mockToken",
+                ["mockToken", "mockToken", 18, await deployer.getAddress(), simpleToExactAmount(1000000)],
+                {},
+                false,
+            );
+            const distributor = accounts[3];
+            const distributorAddress = await distributor.getAddress();
+
+            await mockToken.connect(deployer).approve(distributorAddress, amount);
+            await mockToken.connect(deployer).transfer(distributorAddress, amount);
+            await mockToken.connect(distributor).approve(auraLocker.address, amount);
+
+            await auraLocker.connect(accounts[7]).addReward(mockToken.address, distributorAddress);
+            await auraLocker.connect(accounts[7]).approveRewardDistributor(mockToken.address, distributorAddress, true);
+
+            const tx = await auraLocker.connect(distributor).queueNewRewards(mockToken.address, amount);
+            await expect(tx).to.emit(auraLocker, "RewardAdded").withArgs(mockToken.address, amount);
+            expect(await mockToken.balanceOf(auraLocker.address)).to.equal(amount);
+        });
+
         it("get rewards from CVX locker", async () => {
             await increaseTime(ONE_DAY.mul(105));
             const cvxCrvBefore = await cvxCrv.balanceOf(aliceAddress);
@@ -432,7 +459,7 @@ describe("AuraLocker", () => {
                 dataBefore.account.claimableRewards[0].amount.div(100),
             );
 
-            const tx = await auraLocker["getReward(address)"](aliceAddress);
+            const tx = await auraLocker["getReward(address,bool[])"](aliceAddress, [false, false]);
             const dataAfter = await getSnapShot(aliceAddress);
 
             await tx.wait();
@@ -464,29 +491,40 @@ describe("AuraLocker", () => {
                 .emit(auraLocker, "Withdrawn")
                 .withArgs(aliceAddress, dataBefore.account.balances.locked, relock);
         });
-        it("notify rewards ", async () => {
-            const amount = simpleToExactAmount(100);
-            const mockToken = await deployContract<MockERC20>(
+    });
+
+    context("smart contract deposits", () => {
+        let lockor: MockAuraLockor;
+        before(async () => {
+            lockor = await deployContract<MockAuraLockor>(
                 hre,
-                new MockERC20__factory(deployer),
-                "mockToken",
-                ["mockToken", "mockToken", 18, await deployer.getAddress(), simpleToExactAmount(1000000)],
+                new MockAuraLockor__factory(deployer),
+                "Lockor",
+                [cvx.address, auraLocker.address],
                 {},
                 false,
             );
-            const distributor = accounts[3];
-            const distributorAddress = await distributor.getAddress();
 
-            await mockToken.connect(deployer).approve(distributorAddress, amount);
-            await mockToken.connect(deployer).transfer(distributorAddress, amount);
-            await mockToken.connect(distributor).approve(auraLocker.address, amount);
-
-            await auraLocker.connect(deployer).addReward(mockToken.address, distributorAddress);
-            await auraLocker.connect(deployer).approveRewardDistributor(mockToken.address, distributorAddress, true);
-
-            const tx = await auraLocker.connect(distributor).notifyRewardAmount(mockToken.address, amount);
-            await expect(tx).to.emit(auraLocker, "RewardAdded").withArgs(mockToken.address, amount);
-            expect(await mockToken.balanceOf(auraLocker.address)).to.equal(amount);
+            await cvx.connect(alice).approve(lockor.address, simpleToExactAmount(1000));
+            await cvx.connect(alice).approve(auraLocker.address, simpleToExactAmount(1000));
+        });
+        it("allows smart contract deposits", async () => {
+            await lockor.connect(alice).lock(simpleToExactAmount(10));
+            await lockor.connect(alice).lockFor(aliceAddress, simpleToExactAmount(10));
+        });
+        it("allows blacklisting", async () => {
+            const tx = await auraLocker.connect(accounts[7]).modifyBlacklist(aliceAddress, true);
+            await expect(tx).to.emit(auraLocker, "BlacklistModified").withArgs(aliceAddress, true);
+            expect(await auraLocker.blacklist(aliceAddress)).eq(true);
+        });
+        it("still allows blacklisted EOA's to lock", async () => {
+            await auraLocker.connect(alice).lock(aliceAddress, simpleToExactAmount(10));
+        });
+        it("blocks contracts from depositing when they are blacklisted", async () => {
+            await auraLocker.connect(accounts[7]).modifyBlacklist(lockor.address, true);
+            await expect(lockor.connect(alice).lockFor(bobAddress, simpleToExactAmount(10))).to.be.revertedWith(
+                "blacklisted",
+            );
         });
     });
 
@@ -891,23 +929,41 @@ describe("AuraLocker", () => {
         });
         it("fails if the sender is not rewardsDistributor", async () => {
             // Only the rewardsDistributor can queue cvxCRV rewards
-            await expect(auraLocker.queueNewRewards(simpleToExactAmount(100))).revertedWith("!authorized");
+            await expect(auraLocker.queueNewRewards(cvxCrv.address, simpleToExactAmount(100))).revertedWith(
+                "!authorized",
+            );
         });
         it("fails if the amount of rewards is 0", async () => {
             // Only the rewardsDistributor can queue cvxCRV rewards
             await expect(
-                auraLocker.connect(cvxStakingProxyAccount.signer).queueNewRewards(simpleToExactAmount(0)),
+                auraLocker
+                    .connect(cvxStakingProxyAccount.signer)
+                    .queueNewRewards(cvxCrv.address, simpleToExactAmount(0)),
             ).revertedWith("No reward");
         });
+        it("fails if balance is too low", async () => {
+            await booster.earmarkRewards(boosterPoolId);
+            await increaseTime(ONE_DAY);
+
+            const incentive = await booster.stakerIncentive();
+            const rate = await mocks.crvMinter.rate();
+            const stakingCrvBalance = await mocks.crv.balanceOf(cvxStakingProxy.address);
+
+            expect(stakingCrvBalance).to.equal(rate.mul(incentive).div(10000));
+
+            await expect(cvxStakingProxy["distribute()"]()).to.be.revertedWith("!balance");
+        });
         it("distribute rewards from the booster", async () => {
+            await auraLocker.connect(alice).lock(aliceAddress, simpleToExactAmount(100));
             await distributeRewardsFromBooster();
         });
         it("queues rewards when cvxCrv period is finished", async () => {
-            // AuraStakingProxy.distribute(), faked by impersonating account
+            await auraLocker.connect(alice).lock(aliceAddress, simpleToExactAmount(100));
+            // AuraStakingProxy["distribute()"](), faked by impersonating account
             let rewards = simpleToExactAmount(100);
             const rewardDistribution = await auraLocker.rewardsDuration();
             const cvxCrvLockerBalance0 = await cvxCrv.balanceOf(auraLocker.address);
-            const queuedCvxCrvRewards0 = await auraLocker.queuedCvxCrvRewards();
+            const queuedCvxCrvRewards0 = await auraLocker.queuedRewards(cvxCrv.address);
             const rewardData0 = await auraLocker.rewardData(cvxCrv.address);
             const timeStamp = await getTimestamp();
 
@@ -922,7 +978,7 @@ describe("AuraLocker", () => {
             expect(await cvxCrv.balanceOf(auraLocker.address), "cvxCrv is transfer to locker").to.eq(
                 cvxCrvLockerBalance0.add(rewards),
             );
-            expect(await auraLocker.queuedCvxCrvRewards(), "queued cvxCrv rewards").to.eq(0);
+            expect(await auraLocker.queuedRewards(cvxCrv.address), "queued cvxCrv rewards").to.eq(0);
 
             // Verify reward data is updated, reward rate, lastUpdateTime, periodFinish; when the lastUpdateTime is lt than now.
             expect(rewardData1.lastUpdateTime, "cvxCrv reward last update time").to.gt(rewardData0.lastUpdateTime);
@@ -944,12 +1000,12 @@ describe("AuraLocker", () => {
             expect(timeStamp, "reward period finish").to.gte(rewardData0.periodFinish);
             expect(await cvxCrv.balanceOf(cvxStakingProxyAccount.address)).to.gt(0);
 
-            // cvxStakingProxy.distribute();=>auraLocker.queueNewRewards()
+            // cvxStakingProxy["distribute()"]();=>auraLocker.queueNewRewards()
             // First distribution to update the reward finish period.
             let rewards = await distributeRewardsFromBooster();
             // Validate
             const cvxCrvLockerBalance1 = await cvxCrv.balanceOf(auraLocker.address);
-            const queuedCvxCrvRewards1 = await auraLocker.queuedCvxCrvRewards();
+            const queuedCvxCrvRewards1 = await auraLocker.queuedRewards(cvxCrv.address);
             const rewardData1 = await auraLocker.rewardData(cvxCrv.address);
 
             // Verify reward data is updated, reward rate, lastUpdateTime, periodFinish; when the lastUpdateTime is lt than now.
@@ -967,7 +1023,7 @@ describe("AuraLocker", () => {
             rewards = await distributeRewardsFromBooster();
 
             const cvxCrvLockerBalance2 = await cvxCrv.balanceOf(auraLocker.address);
-            const queuedCvxCrvRewards2 = await auraLocker.queuedCvxCrvRewards();
+            const queuedCvxCrvRewards2 = await auraLocker.queuedRewards(cvxCrv.address);
             const rewardData2 = await auraLocker.rewardData(cvxCrv.address);
 
             // Verify reward data is not updated, as ratio is not reached.
@@ -985,7 +1041,7 @@ describe("AuraLocker", () => {
             rewards = await distributeRewardsFromBooster();
 
             const cvxCrvLockerBalance3 = await cvxCrv.balanceOf(auraLocker.address);
-            const queuedCvxCrvRewards3 = await auraLocker.queuedCvxCrvRewards();
+            const queuedCvxCrvRewards3 = await auraLocker.queuedRewards(cvxCrv.address);
             const rewardData3 = await auraLocker.rewardData(cvxCrv.address);
 
             // Verify reward data is updated, reward rate, lastUpdateTime, periodFinish; when the lastUpdateTime is lt than now.
@@ -1076,15 +1132,15 @@ describe("AuraLocker", () => {
             delegate2 = await accounts[4].getAddress();
 
             // Mint some cvxCRV and add as the reward token manually
-            let tx = await booster.earmarkRewards(boosterPoolId);
-            await tx.wait();
-
-            tx = await cvxStakingProxy.distribute();
-            await tx.wait();
-
-            tx = await cvx.connect(alice).approve(auraLocker.address, simpleToExactAmount(100));
+            let tx = await cvx.connect(alice).approve(auraLocker.address, simpleToExactAmount(100));
             await tx.wait();
             tx = await auraLocker.connect(alice).lock(aliceAddress, simpleToExactAmount(100));
+            await tx.wait();
+
+            tx = await booster.earmarkRewards(boosterPoolId);
+            await tx.wait();
+
+            tx = await cvxStakingProxy["distribute()"]();
             await tx.wait();
 
             const lock = await auraLocker.userLocks(aliceAddress, 0);
@@ -1298,13 +1354,10 @@ describe("AuraLocker", () => {
         before(async () => {
             await setup();
         });
-        it("@notifyRewardAmount adds cvxCrv", async () => {
-            await expect(auraLocker.notifyRewardAmount(cvxCrv.address, 0)).revertedWith("Use queueNewRewards");
+        it("queueNewRewards sender is not a distributor", async () => {
+            await expect(auraLocker.queueNewRewards(cvx.address, 0)).revertedWith("!authorized");
         });
-        it("notifyRewardAmount sender is not a distributor", async () => {
-            await expect(auraLocker.notifyRewardAmount(cvx.address, 0)).revertedWith("Must be rewardsDistributor");
-        });
-        it("@notifyRewardAmount sends wrong amount", async () => {
+        it("@queueNewRewards sends wrong amount", async () => {
             const mockToken = await deployContract<MockERC20>(
                 hre,
                 new MockERC20__factory(deployer),
@@ -1314,11 +1367,11 @@ describe("AuraLocker", () => {
                 false,
             );
             const distributor = accounts[3];
-            await auraLocker.connect(deployer).addReward(mockToken.address, await distributor.getAddress());
+            await auraLocker.connect(accounts[7]).addReward(mockToken.address, await distributor.getAddress());
             await auraLocker
-                .connect(deployer)
+                .connect(accounts[7])
                 .approveRewardDistributor(mockToken.address, await distributor.getAddress(), true);
-            await expect(auraLocker.connect(distributor).notifyRewardAmount(mockToken.address, 0)).revertedWith(
+            await expect(auraLocker.connect(distributor).queueNewRewards(mockToken.address, 0)).revertedWith(
                 "No reward",
             );
         });
@@ -1332,7 +1385,7 @@ describe("AuraLocker", () => {
             );
         });
         it("approves reward wrong arguments", async () => {
-            const tx = auraLocker.approveRewardDistributor(ZERO_ADDRESS, ZERO_ADDRESS, false);
+            const tx = auraLocker.connect(accounts[7]).approveRewardDistributor(ZERO_ADDRESS, ZERO_ADDRESS, false);
             await expect(tx).revertedWith("Reward does not exist");
         });
         it("non admin - shutdowns", async () => {
@@ -1359,18 +1412,20 @@ describe("AuraLocker", () => {
             );
         });
         it("set Kick Incentive with wrong rate", async () => {
-            await expect(auraLocker.setKickIncentive(501, ZERO)).revertedWith("over max rate");
+            await expect(auraLocker.connect(accounts[7]).setKickIncentive(501, ZERO)).revertedWith("over max rate");
         });
         it("set Kick Incentive with wrong delay", async () => {
-            await expect(auraLocker.setKickIncentive(100, 1)).revertedWith("min delay");
+            await expect(auraLocker.connect(accounts[7]).setKickIncentive(100, 1)).revertedWith("min delay");
         });
         it("recover ERC20 with wrong token address", async () => {
-            await expect(auraLocker.recoverERC20(cvx.address, ZERO)).revertedWith("Cannot withdraw staking token");
+            await expect(auraLocker.connect(accounts[7]).recoverERC20(cvx.address, ZERO)).revertedWith(
+                "Cannot withdraw staking token",
+            );
         });
         it("recover ERC20 cannot withdraw reward", async () => {
-            await auraLocker.addReward(cvxCrvRewards.address, cvxCrvRewards.address);
+            await auraLocker.connect(accounts[7]).addReward(cvxCrvRewards.address, cvxCrvRewards.address);
             expect((await auraLocker.rewardData(cvxCrvRewards.address)).lastUpdateTime).to.not.eq(0);
-            await expect(auraLocker.recoverERC20(cvxCrvRewards.address, ZERO)).revertedWith(
+            await expect(auraLocker.connect(accounts[7]).recoverERC20(cvxCrvRewards.address, ZERO)).revertedWith(
                 "Cannot withdraw reward token",
             );
         });
@@ -1387,15 +1442,19 @@ describe("AuraLocker", () => {
             await cvx.connect(alice).approve(auraLocker.address, cvxAmount);
 
             // approves  distributor
-            await auraLocker.approveRewardDistributor(cvxCrv.address, cvxCrvRewards.address, true);
+            await auraLocker.connect(accounts[7]).approveRewardDistributor(cvxCrv.address, cvxCrvRewards.address, true);
             await expect(await auraLocker.rewardDistributors(cvxCrv.address, cvxCrvRewards.address)).to.eq(true);
 
             // disapproves  distributor
-            await auraLocker.approveRewardDistributor(cvxCrv.address, cvxCrvRewards.address, false);
+            await auraLocker
+                .connect(accounts[7])
+                .approveRewardDistributor(cvxCrv.address, cvxCrvRewards.address, false);
             await expect(await auraLocker.rewardDistributors(cvxCrv.address, cvxCrvRewards.address)).to.eq(false);
         });
         it("set Kick Incentive", async () => {
-            await expect(auraLocker.setKickIncentive(100, 3)).emit(auraLocker, "KickIncentiveSet").withArgs(100, 3);
+            await expect(auraLocker.connect(accounts[7]).setKickIncentive(100, 3))
+                .emit(auraLocker, "KickIncentiveSet")
+                .withArgs(100, 3);
             expect(await auraLocker.kickRewardPerEpoch()).to.eq(100);
             expect(await auraLocker.kickRewardEpochDelay()).to.eq(3);
         });
@@ -1412,13 +1471,13 @@ describe("AuraLocker", () => {
             await mockToken.connect(deployer).approve(auraLocker.address, simpleToExactAmount(100));
             await mockToken.connect(deployer).transfer(auraLocker.address, simpleToExactAmount(10));
 
-            const mockDeployerBalanceBefore = await mockToken.balanceOf(await deployer.getAddress());
+            const mockDeployerBalanceBefore = await mockToken.balanceOf(await accounts[7].getAddress());
             const mockLockerBalanceBefore = await mockToken.balanceOf(auraLocker.address);
             expect(mockLockerBalanceBefore, "locker external lp reward").to.eq(simpleToExactAmount(10));
-            const tx = auraLocker.recoverERC20(mockToken.address, simpleToExactAmount(10));
+            const tx = auraLocker.connect(accounts[7]).recoverERC20(mockToken.address, simpleToExactAmount(10));
             await expect(tx).emit(auraLocker, "Recovered").withArgs(mockToken.address, simpleToExactAmount(10));
 
-            const mockDeployerBalanceAfter = await mockToken.balanceOf(await deployer.getAddress());
+            const mockDeployerBalanceAfter = await mockToken.balanceOf(await accounts[7].getAddress());
             const mockLockerBalanceAfter = await mockToken.balanceOf(auraLocker.address);
 
             expect(mockLockerBalanceAfter, "locker external lp reward").to.eq(0);
@@ -1433,7 +1492,7 @@ describe("AuraLocker", () => {
         });
         it("fails if lock", async () => {
             // Given that the aura locker is shutdown
-            await auraLocker.connect(deployer).shutdown();
+            await auraLocker.connect(accounts[7]).shutdown();
             expect(await auraLocker.isShutdown()).to.eq(true);
             // Then it should fail to lock
             const cvxAmount = simpleToExactAmount(100);
@@ -1450,7 +1509,7 @@ describe("AuraLocker", () => {
             await expect(auraLocker.connect(alice).processExpiredLocks(relock)).revertedWith("no exp locks");
 
             // Given that the aura locker is shutdown
-            await auraLocker.connect(deployer).shutdown();
+            await auraLocker.connect(accounts[7]).shutdown();
             expect(await auraLocker.isShutdown()).to.eq(true);
             // Then it should be able to process unexpired locks
 
@@ -1469,7 +1528,7 @@ describe("AuraLocker", () => {
         });
         it("emergencyWithdraw  when user has no locks", async () => {
             // Given that the aura locker is shutdown
-            await auraLocker.connect(deployer).shutdown();
+            await auraLocker.connect(accounts[7]).shutdown();
             expect(await auraLocker.isShutdown()).to.eq(true);
             // It fails if the user has no locks
             await expect(auraLocker.connect(alice).emergencyWithdraw()).revertedWith("Nothing locked");
@@ -1480,7 +1539,7 @@ describe("AuraLocker", () => {
             await cvx.connect(alice).approve(auraLocker.address, cvxAmount);
             let tx = await auraLocker.connect(alice).lock(aliceAddress, cvxAmount);
             // Given that the aura locker is shutdown
-            await auraLocker.connect(deployer).shutdown();
+            await auraLocker.connect(accounts[7]).shutdown();
             expect(await auraLocker.isShutdown()).to.eq(true);
             // Then it should be able to withdraw in an emergency
             const dataBefore = await getSnapShot(aliceAddress);

--- a/test/AuraMath.spec.ts
+++ b/test/AuraMath.spec.ts
@@ -60,6 +60,7 @@ describe("library AuraMath", () => {
                 0,
             );
             expect(await auraMath.AuraMath_div(2, 1)).to.eq(2);
+            expect(await auraMath.AuraMath_div(3, 2)).to.eq(1);
             expect(await auraMath.AuraMath_div(1, 1)).to.eq(1);
             expect(await auraMath.AuraMath_div(ethers.constants.MaxUint256, ethers.constants.MaxUint256)).to.eq(1);
             await expect(auraMath.AuraMath_div(-1, 2), "no negative numbers").to.reverted;

--- a/test/AuraMerkleDrop.spec.ts
+++ b/test/AuraMerkleDrop.spec.ts
@@ -291,11 +291,6 @@ describe("AuraMerkleDrop", () => {
                 merkleDrop.connect(alice).claim(getAccountBalanceProof(tree, aliceAddress, amount), amount, lock),
             ).to.be.revertedWith("!active");
         });
-        it("forward penalty fails if penaltyForwarder is not set", async () => {
-            expect(await merkleDrop.penaltyForwarder(), "penaltyForwarder").to.eq(ZERO_ADDRESS);
-            // Test
-            await expect(merkleDrop.forwardPenalty()).to.be.revertedWith("!forwarder");
-        });
     });
     describe("admin", () => {
         let tree: MerkleTree;

--- a/test/AuraPenaltyForwarder.spec.ts
+++ b/test/AuraPenaltyForwarder.spec.ts
@@ -64,9 +64,7 @@ describe("AuraPenaltyForwarder", () => {
         expect(await penaltyForwarder.lastDistribution(), "lastDistribution").to.lte(currentTime);
     });
     it("forwarder cvx allowance is correct", async () => {
-        expect(await cvx.allowance(penaltyForwarder.address, distributor.address), "allowance").to.eq(
-            ethers.constants.MaxUint256,
-        );
+        expect(await cvx.allowance(penaltyForwarder.address, distributor.address), "allowance").to.eq(0);
     });
     describe("forward", async () => {
         it("fails if the distribution delay is not completed", async () => {

--- a/test/AuraStakingProxy.spec.ts
+++ b/test/AuraStakingProxy.spec.ts
@@ -49,8 +49,11 @@ describe("AuraStakingProxy", () => {
             .mint(operatorAccount.address, simpleToExactAmount(100000, 18));
         await tx.wait();
 
-        tx = await contracts.cvx.connect(operatorAccount.signer).transfer(aliceAddress, simpleToExactAmount(200));
+        tx = await contracts.cvx.connect(operatorAccount.signer).transfer(aliceAddress, simpleToExactAmount(300));
         await tx.wait();
+
+        await contracts.cvx.connect(alice).approve(contracts.cvxLocker.address, simpleToExactAmount(100));
+        await contracts.cvxLocker.connect(alice).lock(aliceAddress, simpleToExactAmount(100));
 
         tx = await contracts.cvx.connect(operatorAccount.signer).transfer(bobAddress, simpleToExactAmount(100));
         await tx.wait();
@@ -243,12 +246,12 @@ describe("AuraStakingProxy", () => {
         it("fails to distribute if caller is not the keeper", async () => {
             const keeper = await accounts[1].getAddress();
             await contracts.cvxStakingProxy.setKeeper(keeper);
-            await expect(contracts.cvxStakingProxy.connect(accounts[0]).distribute()).to.be.revertedWith("!auth");
-            await contracts.cvxStakingProxy.connect(accounts[1]).distribute();
+            await expect(contracts.cvxStakingProxy.connect(accounts[0])["distribute()"]()).to.be.revertedWith("!auth");
+            await contracts.cvxStakingProxy.connect(accounts[1])["distribute()"]();
         });
         it("allows anyone to distribute", async () => {
             await contracts.cvxStakingProxy.setKeeper(ZERO_ADDRESS);
-            await contracts.cvxStakingProxy.connect(accounts[0]).distribute();
+            await contracts.cvxStakingProxy.connect(accounts[0])["distribute()"]();
         });
         it("distribute rewards from the booster", async () => {
             await contracts.booster.earmarkRewards(0);
@@ -260,7 +263,7 @@ describe("AuraStakingProxy", () => {
             expect(stakingProxyBalance).to.equal(rate.mul(incentive).div(10000));
 
             const balanceBefore = await contracts.cvxCrv.balanceOf(contracts.cvxLocker.address);
-            const tx = await contracts.cvxStakingProxy.distribute();
+            const tx = await contracts.cvxStakingProxy["distribute()"]();
             await tx.wait();
 
             const balanceAfter = await contracts.cvxCrv.balanceOf(contracts.cvxLocker.address);

--- a/test/BalLiquidityProvider.spec.ts
+++ b/test/BalLiquidityProvider.spec.ts
@@ -165,7 +165,7 @@ describe("BalLiquidityProvider", () => {
             // Given
             const startTokenBalance = await startTokenContract.balanceOf(balLiquidityProvider.address);
             // set a wrong max amount in start token.
-            joinPoolRequest.maxAmountsIn = [simpleToExactAmount(123), simpleToExactAmount(123)];
+            joinPoolRequest.maxAmountsIn = [simpleToExactAmount(123000), simpleToExactAmount(123000)];
             expect(startTokenBalance, "initial start token balance").to.not.eq(joinPoolRequest.maxAmountsIn[0]);
             // When
             await expect(

--- a/test/ConvexMasterChef.spec.ts
+++ b/test/ConvexMasterChef.spec.ts
@@ -214,7 +214,7 @@ describe("ConvexMasterChef", () => {
             await randomToken.transfer(chef.address, simpleToExactAmount(100000));
 
             // Test
-            await chef.add(1000, randomToken.address, ZERO_ADDRESS, false);
+            await chef.add(1000, randomToken.address, ZERO_ADDRESS);
             // Then
             const poolInfo: PoolInfo = await chef.poolInfo(pidRtkn);
             expect(await chef.totalAllocPoint(), "totalAllocPoint").to.eq(2000);

--- a/test/CrvDepositor.spec.ts
+++ b/test/CrvDepositor.spec.ts
@@ -185,30 +185,8 @@ describe("CrvDepositor", () => {
         });
 
         it("deposit skips lock", async () => {
-            const lock = true;
-            const stakeAddress = "0x0000000000000000000000000000000000000000";
-            const crvBalance = await mocks.crvBpt.balanceOf(aliceAddress);
-            const amount = crvBalance.mul(10).div(100);
-
-            const beforeLockTime = await mocks.votingEscrow.lockTimes(voterProxy.address);
-            const beforeLockAmount = await mocks.votingEscrow.lockAmounts(voterProxy.address);
-            const cvxCrvBalanceBefore = await cvxCrv.balanceOf(aliceAddress);
-
-            const tx = await crvDepositor["deposit(uint256,bool,address)"](amount, lock, stakeAddress);
-            await tx.wait();
-
-            const cvxCrvBalanceAfter = await cvxCrv.balanceOf(aliceAddress);
-            const cvxCrvBalanceDelta = cvxCrvBalanceAfter.sub(cvxCrvBalanceBefore);
-            expect(cvxCrvBalanceDelta).to.equal(amount);
-
-            const afterLockTime = await mocks.votingEscrow.lockTimes(voterProxy.address);
-            const afterLockAmount = await mocks.votingEscrow.lockAmounts(voterProxy.address);
-
-            const lockTimeDelta = afterLockTime.sub(beforeLockTime);
-            const lockAmountDelta = afterLockAmount.sub(beforeLockAmount);
-
-            expect(lockTimeDelta.toString()).to.equal("0");
-            expect(lockAmountDelta.toString()).to.equal("0");
+            const tx = crvDepositor["deposit(uint256,bool,address)"](simpleToExactAmount(1), true, ZERO_ADDRESS);
+            await expect(tx).to.revertedWith("cooldown");
         });
     });
     describe("setting setters", () => {

--- a/test/ExtraRewardsDistributor.spec.ts
+++ b/test/ExtraRewardsDistributor.spec.ts
@@ -66,6 +66,9 @@ describe("ExtraRewardsDistributor", () => {
         mockErc20 = await new MockERC20__factory(alice).deploy("MockERC20", "mk20", 18, aliceAddress, 1000);
         await mockErc20.connect(alice).transfer(bobAddress, simpleToExactAmount(200));
         mockErc20X = await new MockERC20__factory(alice).deploy("MockERC20 X", "MKTX", 18, aliceAddress, 1000);
+
+        await contracts.extraRewardsDistributor.modifyWhitelist(aliceAddress, true);
+        await contracts.extraRewardsDistributor.modifyWhitelist(bobAddress, true);
     });
 
     async function verifyAddRewards(sender: Signer, fundAmount: BN, epoch: number) {
@@ -333,9 +336,7 @@ describe("ExtraRewardsDistributor", () => {
             expect(claimableRewardsAtLatestEpoch, "bob claimable rewards at given epoch").to.gt(0);
             expect(await distributor.userClaims(mockErc20.address, bobAddress), "user claims").to.eq(0);
             // When
-            const tx = distributor
-                .connect(bob)
-                ["getReward(address,address,uint256)"](bobAddress, mockErc20.address, epochIndex);
+            const tx = distributor.connect(bob)["getReward(address,uint256)"](mockErc20.address, epochIndex);
 
             // Then
             await expect(tx)
@@ -364,9 +365,7 @@ describe("ExtraRewardsDistributor", () => {
                 epoch - 1,
             );
             // When
-            const tx = distributor
-                .connect(bob)
-                ["getReward(address,address,uint256)"](bobAddress, mockErc20.address, epoch);
+            const tx = distributor.connect(bob)["getReward(address,uint256)"](mockErc20.address, epoch);
             // Then
             await expect(tx).not.to.emit(distributor, "RewardPaid");
             expect(await mockErc20.balanceOf(bobAddress), "bob balance").to.eq(bobBalanceBefore);

--- a/test/VoterProxy.spec.ts
+++ b/test/VoterProxy.spec.ts
@@ -222,6 +222,7 @@ describe("VoterProxy", () => {
             await auraLocker.lock(deployerAddress, cvxAmount);
             await increaseTime(86400 * 7);
 
+            await extraRewardsDistributor.connect(daoMultisig).modifyWhitelist(voterProxy.address, true);
             await voterProxy.connect(daoMultisig)["withdraw(address)"](randomToken.address);
             const rewardDepositBalance = await randomToken.balanceOf(extraRewardsDistributor.address);
             expect(balance).eq(rewardDepositBalance);


### PR DESCRIPTION
Code4rena findings, post filter, and ordered by contract name.

Proposed severity ratings are in the second column as per code4rena guidelines.

------

Contract | Severity | ID | Note/Fix | URL
-- | -- | -- | -- | --
Aura.sol | 1 | 34 | Add protection on updateOperator | https://github.com/code-423n4/2022-05-aura-findings/issues/34
Aura.sol | 1 | 125 | Add second variable | https://github.com/code-423n4/2022-05-aura-findings/issues/125
Aura.sol | 0 | 24 | Remove libs from aura token | https://github.com/code-423n4/2022-05-aura-findings/issues/24
AuraBalRewardPool.sol | 1 |   | Withdraw to treasuryDAO before rewards start. Also mutate AuraLocker. Backup incase bug is found in system, to prevent auraBAL locking |  
AuraBalRewardPool.sol | 0 | 123 | Protections on constructor | https://github.com/code-423n4/2022-05-aura-findings/issues/123
AuraBalRewardPool.sol | 0 | 167 | Remove safemath from AuraBalRewardPool | https://github.com/code-423n4/2022-05-aura-findings/issues/167
AuraClaimZap.sol | 2 | 108 | Fix as per comment | https://github.com/code-423n4/2022-05-aura-findings/issues/108
AuraLocker.sol | 2 | 261 | maxRewardRate | https://github.com/code-423n4/2022-05-aura-findings/issues/261
AuraLocker.sol | 2 | 278 | Add blacklisting | https://github.com/code-423n4/2022-05-aura-findings/issues/278
AuraLocker.sol | 2 | 178 | max reward tokens on aura locker  Add method to “claimExtras” w/ overload | https://github.com/code-423n4/2022-05-aura-findings/issues/178
AuraLocker.sol | 1 | 1 | Make queueNewRewards generic and update calls | https://github.com/code-423n4/2022-05-aura-findings/issues/1
AuraLocker.sol | 0 | 28 | Remove ABIEncoder | https://github.com/code-423n4/2022-05-aura-findings/issues/28
AuraLocker.sol | 0 | 156 | Just change this to amount | https://github.com/code-423n4/2022-05-aura-findings/issues/156
AuraLocker.sol | 0 | 212 | Just add | https://github.com/code-423n4/2022-05-aura-findings/issues/212
AuraMerkleDrop.sol | 1 |   | Allow withdraw to treasuryDAO within first week before it has started |  
AuraMerkleDrop.sol | 1 | 316 | Subtract pending penalty | https://github.com/code-423n4/2022-05-aura-findings/issues/316
AuraMerkleDrop.sol | 0 | 95 | Add check for non zero addr | https://github.com/code-423n4/2022-05-aura-findings/issues/95
AuraMerkleDrop.sol | 0 | 268 | move penalty forwarder to constructor | https://github.com/code-423n4/2022-05-aura-findings/issues/268
AuraMinter.sol | 0 | 10 | Comment | https://github.com/code-423n4/2022-05-aura-findings/issues/10
AuraVestedEscrow.sol | 1 | 133 | Fix as per comment. ALSO check for mismatching array lengths | https://github.com/code-423n4/2022-05-aura-findings/issues/133
AuraVestedEscrow.sol | 0 | 126 | Simple check to disallow funding | https://github.com/code-423n4/2022-05-aura-findings/issues/126
BalLiquidityProvider.sol | 1 | 90 | Add check | https://github.com/code-423n4/2022-05-aura-findings/issues/90
BalLiquidityProvider.sol | 0 | 285 | add ≥ | https://github.com/code-423n4/2022-05-aura-findings/issues/285
BaseRewardPool.sol | 2 | 178 | max reward tokens on baserewardpool - just add if(max) then do nothing. To avoid bricking, don’t revert. Only called from 2 places: Booster & ExtraRewardsStashV3. StashV3: avoid bricking by limiting manual reward addition. Booster: manual check, will never need more than 10 | https://github.com/code-423n4/2022-05-aura-findings/issues/178
BaseRewardPool4626.sol | 1 | 39 | SafeMath usage | https://github.com/code-423n4/2022-05-aura-findings/issues/39
Booster.sol | 1 | 243 | owner sets vote delegate & feeManager | https://github.com/code-423n4/2022-05-aura-findings/issues/243
ConvexMasterChef.sol | 2 | 313 | Add reentrancyguard | https://github.com/code-423n4/2022-05-aura-findings/issues/313
ConvexMasterChef.sol | 1 | 147 | remove with update arg, add limit && for add, disable rewardToken or duplicates | https://github.com/code-423n4/2022-05-aura-findings/issues/147
CrvDepositor.sol | 2 | 341 | consider disabling minting if cooldown to avoid bpt getting locked | https://github.com/code-423n4/2022-05-aura-findings/issues/341
CrvDepositor.sol | 1 | 343 | If the lock is > 1 week old, increase lock time | https://github.com/code-423n4/2022-05-aura-findings/issues/343
CrvDepositorWrapper.sol | 2 | 115 | Temporary measure to avoid system freezing is to allow the keeper to set a minOut override | https://github.com/code-423n4/2022-05-aura-findings/issues/115
EstraRewardsDistributor.sol | 2 | 50 | Add validation | https://github.com/code-423n4/2022-05-aura-findings/issues/50
ExtraRewardsDistributor.sol | 1 | 240 | Whitelisted accs only can add | https://github.com/code-423n4/2022-05-aura-findings/issues/240
ExtraRewardsDistributor.sol | 1 | 5 | Simply add > 0. Doesn’t do much tbh but already changing smth else | https://github.com/code-423n4/2022-05-aura-findings/issues/5
ExtraRewardsDistributor.sol | 0 | 230 | Make fn private & add reentrancyguard | https://github.com/code-423n4/2022-05-aura-findings/issues/230
Interfaces.sol | 0 | 249 | remove abicoderv2 | https://github.com/code-423n4/2022-05-aura-findings/issues/249
Many | 0 | 172 | compiler and comments | https://github.com/code-423n4/2022-05-aura-findings/issues/172
Many | 0 | 107 | mass update and lock compiler v | https://github.com/code-423n4/2022-05-aura-findings/issues/107
PenaltyForwarder.sol | 0 | 49 | Mutate ExtraRewardsDistributor | https://github.com/code-423n4/2022-05-aura-findings/issues/49
StashFactoryV2.sol | 0 | 362 | add non zero gauge check | https://github.com/code-423n4/2022-05-aura-findings/issues/362


